### PR TITLE
Feature/auth via third party and token

### DIFF
--- a/lib/auth/third_party_authenticator.dart
+++ b/lib/auth/third_party_authenticator.dart
@@ -1,0 +1,17 @@
+import 'package:googleapis_auth/src/access_credentials.dart';
+import 'package:grpc/grpc.dart';
+import 'package:http/http.dart' as http;
+
+/// An abstract class for authenticating with a third party.
+class ThirdPartyAuthenticator extends HttpBasedAuthenticator {
+  final Future<AccessCredentials> Function() obtainCredentialsFromThirdParty;
+
+  ThirdPartyAuthenticator({
+    required this.obtainCredentialsFromThirdParty,
+  });
+
+  @override
+  Future<AccessCredentials> obtainCredentialsWithClient(http.Client client, String uri) {
+    return obtainCredentialsFromThirdParty();
+  }
+}

--- a/lib/auth/third_party_authenticator.dart
+++ b/lib/auth/third_party_authenticator.dart
@@ -2,7 +2,7 @@ import 'package:googleapis_auth/src/access_credentials.dart';
 import 'package:grpc/grpc.dart';
 import 'package:http/http.dart' as http;
 
-/// An abstract class for authenticating with a third party.
+/// Class for authenticating with a third party.
 class ThirdPartyAuthenticator extends HttpBasedAuthenticator {
   final Future<AccessCredentials> Function() obtainCredentialsFromThirdParty;
 

--- a/lib/google_speech.dart
+++ b/lib/google_speech.dart
@@ -6,3 +6,5 @@ export 'exception.dart';
 export 'speech_client_authenticator.dart';
 export 'speech_to_text.dart';
 export 'speech_to_text_beta.dart';
+export 'auth/third_party_authenticator.dart';
+export 'package:googleapis_auth/src/access_credentials.dart' show AccessCredentials;

--- a/lib/speech_to_text.dart
+++ b/lib/speech_to_text.dart
@@ -2,6 +2,7 @@ library flutter_google_speech;
 
 import 'dart:async';
 
+import 'package:google_speech/auth/third_party_authenticator.dart';
 import 'package:google_speech/generated/google/cloud/speech/v1/cloud_speech.pb.dart'
     hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/generated/google/cloud/speech/v1/cloud_speech.pbgrpc.dart'
@@ -29,6 +30,26 @@ class SpeechToText {
   /// Creates a SpeechToText interface using a service account.
   factory SpeechToText.viaServiceAccount(ServiceAccount account) =>
       SpeechToText._(account.callOptions);
+
+  /// Creates a SpeechToText interface using a third party authenticator.
+  /// Don't worry about updating the access token, the package does it automatically.
+  /// Example:
+  ///       final speechToText = SpeechToText.viaThirdPartyAuthenticator(
+  ///         ThirdPartyAuthenticator(
+  ///           obtainCredentialsFromThirdParty: () async {
+  ///             // request api to get token
+  ///             final json = await requestCredentialFromMyApi();
+  ///             return AccessCredentials.fromJson(json);
+  ///           },
+  ///         ),
+  ///       );
+  factory SpeechToText.viaThirdPartyAuthenticator(ThirdPartyAuthenticator thirdPartyAuthenticator) =>
+      SpeechToText._(thirdPartyAuthenticator.toCallOptions);
+
+  /// Creates a SpeechToText interface using a token.
+  /// You are responsible for updating the token when it expires.
+  factory SpeechToText.viaToken(String typeToken, String token) =>
+      SpeechToText._(CallOptions(metadata: {'authorization': '$typeToken $token'}));
 
   /// Listen to audio stream.
   /// Cancelled as soon as dispose is called.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,7 +165,7 @@ packages:
     dependency: "direct main"
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: "6a2ef17156f4dc49684f9d99aaf4a93aba8ac49f5eac861755f5730ddf6e2e4e"
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct main"
     description:
       name: fixnum
-      sha256: "6a2ef17156f4dc49684f9d99aaf4a93aba8ac49f5eac861755f5730ddf6e2e4e"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -497,5 +497,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -168,7 +168,7 @@ packages:
       sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -497,5 +497,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
Added support via third-party and token-based authentication.

Fixed security issue by avoiding storing Google Account Service credentials within the application; instead, the token is obtained from a third-party API

Ref.: #8  #41

Via Third Party Authenticator
```
final speechToText = SpeechToText.viaThirdPartyAuthenticator(
      ThirdPartyAuthenticator(
        obtainCredentialsFromThirdParty: () async {
          // request api to get token
          final resultExample = '{
            "accessToken": {
              "type": "Bearer",
              "data": "<token-here>",
              "expiry": "2024-05-28T23:59:59.0000000Z",
            },
            "scopes": [
              "https://www.googleapis.com/auth/cloud-platform",
            ],
          }';
          return AccessCredentials.fromJson(resultExample);
        },
      ),
    );
```

Via Token (bonus)
```
    final speechToText = SpeechToText.viaToken(
      'Bearer',
      '<token-here>',
    );
```
    