### PR TITLE
Setup to take in optional metadata keys/values to support api key restricting

### DIFF
--- a/lib/speech_to_text.dart
+++ b/lib/speech_to_text.dart
@@ -1,12 +1,9 @@
 library flutter_google_speech;
 
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:google_speech/auth/third_party_authenticator.dart';
 import 'package:google_speech/config/longrunning_result.dart';
-import 'package:google_speech/generated/google/cloud/speech/v1/cloud_speech.pb.dart'
-    hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/generated/google/cloud/speech/v1/cloud_speech.pbgrpc.dart'
     hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/generated/google/longrunning/operations.pbgrpc.dart';
@@ -15,7 +12,6 @@ import 'package:grpc/grpc.dart';
 
 import 'config/recognition_config_v1.dart';
 import 'config/streaming_recognition_config.dart';
-import 'generated/google/longrunning/operations.pb.dart';
 
 /// An interface to Google's Speech-to-Text Api via grpc.
 ///
@@ -34,15 +30,26 @@ class SpeechToText {
   }) : _channel = ClientChannel(cloudSpeechEndpoint ?? 'speech.googleapis.com');
 
   /// Creates a SpeechToText interface using a service account.
-  factory SpeechToText.viaServiceAccount(ServiceAccount account,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToText._(account.callOptions,
+  factory SpeechToText.viaServiceAccount(
+    ServiceAccount account, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToText._(
+          account.callOptions.mergedWith(CallOptions(metadata: metadata ?? {})),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToText interface using a API keys.
-  factory SpeechToText.viaApiKey(String apiKey,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToText._(CallOptions(metadata: {'X-goog-api-key': '$apiKey'}),
+  factory SpeechToText.viaApiKey(
+    String apiKey, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToText._(
+          CallOptions(metadata: {
+            'X-goog-api-key': '$apiKey',
+            ...?metadata,
+          }),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToText interface using a third party authenticator.
@@ -58,17 +65,28 @@ class SpeechToText {
   ///         ),
   ///       );
   factory SpeechToText.viaThirdPartyAuthenticator(
-          ThirdPartyAuthenticator thirdPartyAuthenticator,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToText._(thirdPartyAuthenticator.toCallOptions,
+    ThirdPartyAuthenticator thirdPartyAuthenticator, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToText._(
+          thirdPartyAuthenticator.toCallOptions
+              .mergedWith(CallOptions(metadata: metadata ?? {})),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToText interface using a token.
   /// You are responsible for updating the token when it expires.
-  factory SpeechToText.viaToken(String typeToken, String token,
-          {String? cloudSpeechEndpoint}) =>
+  factory SpeechToText.viaToken(
+    String typeToken,
+    String token, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
       SpeechToText._(
-          CallOptions(metadata: {'authorization': '$typeToken $token'}),
+          CallOptions(metadata: {
+            'authorization': '$typeToken $token',
+            ...?metadata,
+          }),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Listen to audio stream.

--- a/lib/speech_to_text_beta.dart
+++ b/lib/speech_to_text_beta.dart
@@ -4,8 +4,6 @@ import 'dart:async';
 
 import 'package:google_speech/config/longrunning_result.dart';
 import 'package:google_speech/config/recognition_config_v1p1beta1.dart';
-import 'package:google_speech/generated/google/cloud/speech/v1p1beta1/cloud_speech.pb.dart'
-    hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/generated/google/cloud/speech/v1p1beta1/cloud_speech.pbgrpc.dart'
     hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/speech_client_authenticator.dart';
@@ -14,7 +12,6 @@ import 'package:grpc/grpc.dart';
 import 'auth/third_party_authenticator.dart';
 import 'config/recognition_config_v1.dart';
 import 'config/streaming_recognition_config.dart';
-import 'generated/google/longrunning/operations.pb.dart';
 import 'generated/google/longrunning/operations.pbgrpc.dart';
 
 /// An interface to Google's Speech-to-Text Api via grpc.
@@ -33,15 +30,26 @@ class SpeechToTextBeta {
             ClientChannel(cloudSpeechEndpoint ?? 'speech.googleapis.com');
 
   /// Creates a SpeechToText interface using a service account.
-  factory SpeechToTextBeta.viaServiceAccount(ServiceAccount account,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToTextBeta._(account.callOptions,
+  factory SpeechToTextBeta.viaServiceAccount(
+    ServiceAccount account, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToTextBeta._(
+          account.callOptions.mergedWith(CallOptions(metadata: metadata ?? {})),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToText interface using a API keys.
-  factory SpeechToTextBeta.viaApiKey(String apiKey,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToTextBeta._(CallOptions(metadata: {'X-goog-api-key': '$apiKey'}),
+  factory SpeechToTextBeta.viaApiKey(
+    String apiKey, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToTextBeta._(
+          CallOptions(metadata: {
+            'X-goog-api-key': '$apiKey',
+            ...?metadata,
+          }),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToText interface using a third party authenticator.
@@ -57,17 +65,28 @@ class SpeechToTextBeta {
   ///         ),
   ///       );
   factory SpeechToTextBeta.viaThirdPartyAuthenticator(
-          ThirdPartyAuthenticator thirdPartyAuthenticator,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToTextBeta._(thirdPartyAuthenticator.toCallOptions,
+    ThirdPartyAuthenticator thirdPartyAuthenticator, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToTextBeta._(
+          thirdPartyAuthenticator.toCallOptions
+              .mergedWith(CallOptions(metadata: metadata ?? {})),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToTextBeta interface using a token.
   /// You are responsible for updating the token when it expires.
-  factory SpeechToTextBeta.viaToken(String typeToken, String token,
-          {String? cloudSpeechEndpoint}) =>
+  factory SpeechToTextBeta.viaToken(
+    String typeToken,
+    String token, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
       SpeechToTextBeta._(
-          CallOptions(metadata: {'authorization': '$typeToken $token'}),
+          CallOptions(metadata: {
+            'authorization': '$typeToken $token',
+            ...?metadata,
+          }),
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Listen to audio stream.

--- a/lib/speech_to_text_v2.dart
+++ b/lib/speech_to_text_v2.dart
@@ -4,8 +4,6 @@ import 'dart:async';
 
 import 'package:google_speech/auth/third_party_authenticator.dart';
 import 'package:google_speech/config/longrunning_result.dart';
-import 'package:google_speech/generated/google/cloud/speech/v2/cloud_speech.pb.dart'
-    hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/generated/google/cloud/speech/v2/cloud_speech.pbgrpc.dart'
     hide RecognitionConfig, StreamingRecognitionConfig;
 import 'package:google_speech/generated/google/longrunning/operations.pbgrpc.dart';
@@ -14,7 +12,6 @@ import 'package:grpc/grpc.dart';
 
 import 'config/recognition_config_v2.dart';
 import 'config/streaming_recognition_config.dart';
-import 'generated/google/longrunning/operations.pb.dart';
 
 /// An interface to Google's Speech-to-Text Api via grpc.
 ///
@@ -36,16 +33,31 @@ class SpeechToTextV2 {
             ClientChannel(cloudSpeechEndpoint ?? 'speech.googleapis.com');
 
   /// Creates a SpeechToTextV2 interface using a service account.
-  factory SpeechToTextV2.viaServiceAccount(ServiceAccount account,
-          {required String projectId, String? cloudSpeechEndpoint}) =>
-      SpeechToTextV2._(account.callOptions,
-          projectId: projectId, cloudSpeechEndpoint: cloudSpeechEndpoint);
+  factory SpeechToTextV2.viaServiceAccount(
+    ServiceAccount account, {
+    required String projectId,
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToTextV2._(
+          account.callOptions.mergedWith(CallOptions(metadata: metadata ?? {})),
+          projectId: projectId,
+          cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToText interface using a API keys.
-  factory SpeechToTextV2.viaApiKey(String apiKey, String projectId,
-          {String? cloudSpeechEndpoint}) =>
-      SpeechToTextV2._(CallOptions(metadata: {'X-goog-api-key': '$apiKey'}),
-          projectId: projectId, cloudSpeechEndpoint: cloudSpeechEndpoint);
+  factory SpeechToTextV2.viaApiKey(
+    String apiKey,
+    String projectId, {
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToTextV2._(
+          CallOptions(metadata: {
+            'X-goog-api-key': '$apiKey',
+            ...?metadata,
+          }),
+          projectId: projectId,
+          cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToTextV2 interface using a third party authenticator.
   /// Don't worry about updating the access token, the package does it automatically.
@@ -60,18 +72,31 @@ class SpeechToTextV2 {
   ///         ),
   ///       );
   factory SpeechToTextV2.viaThirdPartyAuthenticator(
-          ThirdPartyAuthenticator thirdPartyAuthenticator,
-          {required String projectId,
-          String? cloudSpeechEndpoint}) =>
-      SpeechToTextV2._(thirdPartyAuthenticator.toCallOptions,
-          projectId: projectId, cloudSpeechEndpoint: cloudSpeechEndpoint);
+    ThirdPartyAuthenticator thirdPartyAuthenticator, {
+    required String projectId,
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
+      SpeechToTextV2._(
+          thirdPartyAuthenticator.toCallOptions
+              .mergedWith(CallOptions(metadata: metadata ?? {})),
+          projectId: projectId,
+          cloudSpeechEndpoint: cloudSpeechEndpoint);
 
   /// Creates a SpeechToTextV2 interface using a token.
   /// You are responsible for updating the token when it expires.
-  factory SpeechToTextV2.viaToken(String typeToken, String token,
-          {required String projectId, String? cloudSpeechEndpoint}) =>
+  factory SpeechToTextV2.viaToken(
+    String typeToken,
+    String token, {
+    required String projectId,
+    String? cloudSpeechEndpoint,
+    Map<String, String>? metadata,
+  }) =>
       SpeechToTextV2._(
-          CallOptions(metadata: {'authorization': '$typeToken $token'}),
+          CallOptions(metadata: {
+            'authorization': '$typeToken $token',
+            ...?metadata,
+          }),
           projectId: projectId,
           cloudSpeechEndpoint: cloudSpeechEndpoint);
 
@@ -132,7 +157,8 @@ class SpeechToTextV2 {
   /// To use asynchronous speech recognition to transcribe audio longer than 60
   /// seconds, you must have your data saved in a Google Cloud Storage bucket.
   ResponseFuture<Operation> longRunningRecognize(
-      RecognitionConfigV2 config, String audioGcsUri, { String location = 'global'}) {
+      RecognitionConfigV2 config, String audioGcsUri,
+      {String location = 'global'}) {
     final client = SpeechClient(_channel, options: _options);
 
     // transform audio to RecognitionAudio
@@ -161,7 +187,8 @@ class SpeechToTextV2 {
   /// the Operation is finished.
   Future<LongRunningRequestResult> pollingLongRunningRecognize(
       RecognitionConfigV2 config, String audioGcsUri,
-      {Duration pollInterval = const Duration(seconds: 1), String location = 'global'}) async {
+      {Duration pollInterval = const Duration(seconds: 1),
+      String location = 'global'}) async {
     final client = SpeechClient(_channel, options: _options);
 
     // transform audio to RecognitionAudio


### PR DESCRIPTION
Developers can restrict their api keys to only work with certain android/iOS apps but they need to specify some additional metadata in the grpc requests. 

See: https://cloud.google.com/docs/authentication/api-keys#api_key_restrictions

And for android specifically: https://cloud.google.com/docs/authentication/api-keys#api_key_restrictions