### PR TITLE
enable intentional restart of endless streaming.

### DIFF
--- a/lib/endless_streaming_service.dart
+++ b/lib/endless_streaming_service.dart
@@ -157,16 +157,17 @@ class EndlessStreamingService {
       _endlessStream.addError(error);
     });
 
-    _resetTimer = Timer(_restartTime, _restart);
+    _resetTimer = Timer(_restartTime, restart);
   }
 
-  Future<void> _restart() async {
+  Future<void> restart() async {
     _transitioning = true;
     await Future.delayed(_transitionBufferTime);
     await _audioStreamSubscription?.cancel();
     _audioStreamSubscription = null;
     await _streamingRecognizeSubscription.cancel();
     await _request.close();
+    _resetTimer?.cancel();
     if (!_audioStreamIsFinished) {
       _startStream();
     }

--- a/lib/endless_streaming_service_beta.dart
+++ b/lib/endless_streaming_service_beta.dart
@@ -157,16 +157,17 @@ class EndlessStreamingServiceBeta {
       _endlessStream.addError(error);
     });
 
-    _resetTimer = Timer(_restartTime, _restart);
+    _resetTimer = Timer(_restartTime, restart);
   }
 
-  Future<void> _restart() async {
+  Future<void> restart() async {
     _transitioning = true;
     await Future.delayed(_transitionBufferTime);
     await _audioStreamSubscription?.cancel();
     _audioStreamSubscription = null;
     await _streamingRecognizeSubscription.cancel();
     await _request.close();
+    _resetTimer?.cancel();
     if (!_audioStreamIsFinished) {
       _startStream();
     }

--- a/lib/endless_streaming_service_v2.dart
+++ b/lib/endless_streaming_service_v2.dart
@@ -181,16 +181,17 @@ class EndlessStreamingServiceV2 {
       _endlessStream.addError(error);
     });
 
-    _resetTimer = Timer(_restartTime, _restart);
+    _resetTimer = Timer(_restartTime, restart);
   }
 
-  Future<void> _restart() async {
+  Future<void> restart() async {
     _transitioning = true;
     await Future.delayed(_transitionBufferTime);
     await _audioStreamSubscription?.cancel();
     _audioStreamSubscription = null;
     await _streamingRecognizeSubscription.cancel();
     await _request.close();
+    _resetTimer?.cancel();
     if (!_audioStreamIsFinished) {
       _startStream();
     }


### PR DESCRIPTION
# Goal: enable the intentional restart of endless streaming.
Google Speech to Text streaming API doesn't finalize the result until the connections close.
This behavior is sometimes inconvenient because the result text is too long to handle.

So. It is convenient to restart the recognition intentionally.

# What I did: make _restart public
To realize the goal, I modified the EndlessStreamingService class to make _restart public.
- renamed the function to restart()
- reset the _resetTimer timer.
- modified v1/v2/beta classes
